### PR TITLE
fix: include qr code

### DIFF
--- a/src/templates/invoice/Invoice.tsx
+++ b/src/templates/invoice/Invoice.tsx
@@ -3,6 +3,7 @@ import React, { FunctionComponent } from "react";
 import { Invoice } from "./types";
 import { format } from "date-fns";
 import styled from "@emotion/styled";
+import { DocumentQrCode } from "../../core/DocumentQrCode";
 
 const Container = styled.div`
   font-family: "Lucida Sans Unicode", "Lucida Grande", sans-serif;
@@ -54,6 +55,7 @@ export const InvoiceTemplate: FunctionComponent<TemplateProps<Invoice>> = ({ doc
     taxTotal = 0,
     total = 0
   } = document;
+  const qrCodeUrl = document?.links?.self.href;
 
   return (
     <Container className="p-4 mx-auto container" data-testid="invoice-template">
@@ -160,6 +162,7 @@ export const InvoiceTemplate: FunctionComponent<TemplateProps<Invoice>> = ({ doc
           <p className="font-bold">{total}</p>
         </div>
       </div>
+      {qrCodeUrl && <DocumentQrCode url={qrCodeUrl} />}
     </Container>
   );
 };

--- a/src/templates/invoice/sample.ts
+++ b/src/templates/invoice/sample.ts
@@ -51,5 +51,11 @@ export const invoice: Invoice = {
     name: "INVOICE",
     type: "EMBEDDED_RENDERER",
     url: "http://localhost:3000"
+  },
+  links: {
+    self: {
+      href:
+        "https://action.openattestation.com/?q=%7B%22type%22:%22DOCUMENT%22,%22payload%22:%7B%22uri%22:%22https://gallery.openattestation.com/static/documents/invoice-ropsten.json%22,%22permittedActions%22:%5B%22VIEW%22%5D,%22redirect%22:%22https://dev.tradetrust.io%22%7D%7D"
+    }
   }
 };


### PR DESCRIPTION
This PR contains a fix which includes the QR code for the invoice template: 
<img width="592" alt="Screenshot 2020-11-12 at 2 53 52 PM" src="https://user-images.githubusercontent.com/38589870/98905735-e5bf3400-24f6-11eb-9181-8b128d584749.png">
