### PR TITLE
fix: simple coo data handling

### DIFF
--- a/application/index.tsx
+++ b/application/index.tsx
@@ -11,7 +11,8 @@ import { CoveringLetterSample3 } from "../src/templates/CoveringLetter/sample3";
 import { InvoiceSampleV2 } from "../src/templates/Invoice/sampleV2";
 import { InvoiceSampleV3 } from "../src/templates/Invoice/sampleV3";
 import { XMLRendererSampleData } from "../src/templates/XmlRenderer/sample";
-import { SimpleCooSample } from "../src/templates/SimpleCoo/sample";
+import { SimpleCooSampleV2 } from "../src/templates/SimpleCoo/sampleV2";
+import { SimpleCooSampleV3 } from "../src/templates/SimpleCoo/sampleV3";
 import { App } from "./app";
 
 ReactDOM.render(
@@ -28,7 +29,8 @@ ReactDOM.render(
       { name: "InvoiceV2", document: InvoiceSampleV2 },
       { name: "InvoiceV3", document: InvoiceSampleV3 },
       { name: "XML Renderer", document: XMLRendererSampleData },
-      { name: "Simple COO", document: SimpleCooSample },
+      { name: "Simple COO V2", document: SimpleCooSampleV2 },
+      { name: "Simple COO V3", document: SimpleCooSampleV3 },
     ]}
   />,
   document.getElementById("root")

--- a/src/templates/SimpleCoo/SimpleCooTemplate.stories.tsx
+++ b/src/templates/SimpleCoo/SimpleCooTemplate.stories.tsx
@@ -1,0 +1,24 @@
+import React, { FunctionComponent } from "react";
+import { SimpleCooTemplate } from "./SimpleCooTemplate";
+import { SimpleCooSampleV2 } from "./sampleV2";
+import { SimpleCooSampleV3 } from "./sampleV3";
+
+export default {
+  title: "SimpleCooTemplate",
+  component: SimpleCooTemplate,
+  parameters: {
+    componentSubtitle: "Simple COO template.",
+  },
+};
+
+export const ChaftaCooEmpty: FunctionComponent = () => {
+  return <SimpleCooTemplate document={{} as any} handleObfuscation={() => {}} />;
+};
+
+export const ChaftaCooV2: FunctionComponent = () => {
+  return <SimpleCooTemplate document={SimpleCooSampleV2} handleObfuscation={() => {}} />;
+};
+
+export const ChaftaCooV3: FunctionComponent = () => {
+  return <SimpleCooTemplate document={SimpleCooSampleV3} handleObfuscation={() => {}} />;
+};

--- a/src/templates/SimpleCoo/SimpleCooTemplate.stories.tsx
+++ b/src/templates/SimpleCoo/SimpleCooTemplate.stories.tsx
@@ -11,14 +11,14 @@ export default {
   },
 };
 
-export const ChaftaCooEmpty: FunctionComponent = () => {
+export const SimpleCooEmpty: FunctionComponent = () => {
   return <SimpleCooTemplate document={{} as any} handleObfuscation={() => {}} />;
 };
 
-export const ChaftaCooV2: FunctionComponent = () => {
+export const SimpleCooV2: FunctionComponent = () => {
   return <SimpleCooTemplate document={SimpleCooSampleV2} handleObfuscation={() => {}} />;
 };
 
-export const ChaftaCooV3: FunctionComponent = () => {
+export const SimpleCooV3: FunctionComponent = () => {
   return <SimpleCooTemplate document={SimpleCooSampleV3} handleObfuscation={() => {}} />;
 };

--- a/src/templates/SimpleCoo/SimpleCooTemplate.test.tsx
+++ b/src/templates/SimpleCoo/SimpleCooTemplate.test.tsx
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import React from "react";
+import { SimpleCooTemplate } from "./SimpleCooTemplate";
+import { SimpleCooSampleV2 } from "./sampleV2";
+import { SimpleCooSampleV3 } from "./sampleV3";
+
+describe("simple coo v2", () => {
+  it("should render titles correctly", () => {
+    render(<SimpleCooTemplate document={SimpleCooSampleV2} handleObfuscation={() => {}} />);
+    expect(screen.getAllByText("Certificate of Origin")).toHaveLength(2);
+  });
+
+  it("should render firstSignatoryAuthentication correctly", () => {
+    render(<SimpleCooTemplate document={SimpleCooSampleV2} handleObfuscation={() => {}} />);
+    expect(screen.getByTestId("signature-first")).toBeInTheDocument();
+  });
+
+  it("should render secondSignatoryAuthentication correctly", () => {
+    render(<SimpleCooTemplate document={SimpleCooSampleV2} handleObfuscation={() => {}} />);
+    expect(screen.getByTestId("signature-second")).toBeInTheDocument();
+  });
+});
+
+describe("simple coo v3", () => {
+  it("should render titles correctly", () => {
+    render(<SimpleCooTemplate document={SimpleCooSampleV3} handleObfuscation={() => {}} />);
+    expect(screen.getAllByText("Certificate of Origin")).toHaveLength(2);
+  });
+
+  it("should render firstSignatoryAuthentication correctly", () => {
+    render(<SimpleCooTemplate document={SimpleCooSampleV3} handleObfuscation={() => {}} />);
+    expect(screen.getByTestId("signature-first")).toBeInTheDocument();
+  });
+
+  it("should render secondSignatoryAuthentication correctly", () => {
+    render(<SimpleCooTemplate document={SimpleCooSampleV3} handleObfuscation={() => {}} />);
+    expect(screen.getByTestId("signature-second")).toBeInTheDocument();
+  });
+});
+
+describe("simple coo empty", () => {
+  it("should render titles correctly", () => {
+    render(<SimpleCooTemplate document={{} as any} handleObfuscation={() => {}} />);
+    expect(screen.getAllByText("Certificate of Origin")).toHaveLength(2);
+  });
+});

--- a/src/templates/SimpleCoo/SimpleCooTemplate.tsx
+++ b/src/templates/SimpleCoo/SimpleCooTemplate.tsx
@@ -23,16 +23,12 @@ export const SimpleCooTemplate: FunctionComponent<TemplateProps<SimpleCooDocumen
     return (
       <>
         <h5 className="font-bold mb-4">Exporter&apos;s Name Address and Country</h5>
-        {exporterDetails && (
-          <>
-            <p>{exporterDetails.exporterName}</p>
-            <p>{exporterDetails.exporterAddress.line1}</p>
-            <p>
-              {exporterDetails.exporterAddress.line2} {exporterDetails.exporterAddress.postalCode}
-            </p>
-            <p>{exporterDetails.exportCountry}</p>
-          </>
-        )}
+        <p>{exporterDetails?.exporterName}</p>
+        <p>{exporterDetails?.exporterAddress.line1}</p>
+        <p>
+          {exporterDetails?.exporterAddress.line2} {exporterDetails?.exporterAddress.postalCode}
+        </p>
+        <p>{exporterDetails?.exportCountry}</p>
       </>
     );
   };
@@ -41,15 +37,11 @@ export const SimpleCooTemplate: FunctionComponent<TemplateProps<SimpleCooDocumen
     return (
       <>
         <h5 className="font-bold mb-4">Importer&apos;s Name Address and Country</h5>
-        {importerDetails && (
-          <>
-            <p>{importerDetails.importerName}</p>
-            <p>{importerDetails.importerAddress.line1}</p>
-            <p>{importerDetails.importerAddress.line2}</p>
-            <p>{importerDetails.importerAddress.postalCode}</p>
-            <p>{importerDetails.importCountry}</p>
-          </>
-        )}
+        <p>{importerDetails?.importerName}</p>
+        <p>{importerDetails?.importerAddress.line1}</p>
+        <p>{importerDetails?.importerAddress.line2}</p>
+        <p>{importerDetails?.importerAddress.postalCode}</p>
+        <p>{importerDetails?.importCountry}</p>
       </>
     );
   };

--- a/src/templates/SimpleCoo/SimpleCooTemplate.tsx
+++ b/src/templates/SimpleCoo/SimpleCooTemplate.tsx
@@ -2,9 +2,10 @@ import { TemplateProps } from "@govtechsg/decentralized-renderer-react-component
 import React, { FunctionComponent } from "react";
 import { Wrapper } from "../../core/Wrapper";
 import { SimpleCooDocumentSchema } from "./types";
+import { getDocumentData } from "./../../utils";
 
 export const SimpleCooTemplate: FunctionComponent<TemplateProps<SimpleCooDocumentSchema>> = ({ document }) => {
-  const { credentialSubject } = document;
+  const documentData = getDocumentData(document);
 
   const {
     documentName,
@@ -16,31 +17,22 @@ export const SimpleCooTemplate: FunctionComponent<TemplateProps<SimpleCooDocumen
     issueIn,
     firstSignatoryAuthentication,
     secondSignatoryAuthentication,
-  } = credentialSubject;
-
-  const { exporterAddress, exportCountry, exporterName } = exporterDetails;
-  const { importerAddress, importCountry, importerName } = importerDetails;
-  const {
-    includedConsignments,
-    importerNameMarksAndNumber,
-    hsCode,
-    invoiceNumber,
-    dateOfInvoice,
-    loadingBaseportLocationName,
-    mainCarriageTransportMovementId,
-    numberAndKindOfPackage,
-  } = descriptionOfGoods;
+  } = documentData;
 
   const ExporterSection: FunctionComponent = () => {
     return (
       <>
         <h5 className="font-bold mb-4">Exporter&apos;s Name Address and Country</h5>
-        <p>{exporterName}</p>
-        <p>{exporterAddress.line1}</p>
-        <p>
-          {exporterAddress.line2} {exporterAddress.postalCode}
-        </p>
-        <p>{exportCountry}</p>
+        {exporterDetails && (
+          <>
+            <p>{exporterDetails.exporterName}</p>
+            <p>{exporterDetails.exporterAddress.line1}</p>
+            <p>
+              {exporterDetails.exporterAddress.line2} {exporterDetails.exporterAddress.postalCode}
+            </p>
+            <p>{exporterDetails.exportCountry}</p>
+          </>
+        )}
       </>
     );
   };
@@ -49,11 +41,15 @@ export const SimpleCooTemplate: FunctionComponent<TemplateProps<SimpleCooDocumen
     return (
       <>
         <h5 className="font-bold mb-4">Importer&apos;s Name Address and Country</h5>
-        <p>{importerName}</p>
-        <p>{importerAddress.line1}</p>
-        <p>{importerAddress.line2}</p>
-        <p>{importerAddress.postalCode}</p>
-        <p>{importCountry}</p>
+        {importerDetails && (
+          <>
+            <p>{importerDetails.importerName}</p>
+            <p>{importerDetails.importerAddress.line1}</p>
+            <p>{importerDetails.importerAddress.line2}</p>
+            <p>{importerDetails.importerAddress.postalCode}</p>
+            <p>{importerDetails.importCountry}</p>
+          </>
+        )}
       </>
     );
   };
@@ -77,11 +73,11 @@ export const SimpleCooTemplate: FunctionComponent<TemplateProps<SimpleCooDocumen
     );
   };
 
-  const StandardSection: FunctionComponent<{ label: string; value: string }> = ({ label, value }) => {
+  const StandardSection: FunctionComponent<{ label: string; value?: string }> = ({ label, value }) => {
     return (
       <>
         <h5 className="mb-4 font-bold">{label}</h5>
-        <p>{value}</p>
+        {value && <p>{value}</p>}
       </>
     );
   };
@@ -89,11 +85,12 @@ export const SimpleCooTemplate: FunctionComponent<TemplateProps<SimpleCooDocumen
   const DeclarationSection: FunctionComponent = () => {
     return (
       <>
-        <h5 className="mb-4 font-bold">
-          Declaration by the exporter or producer {firstSignatoryAuthentication?.statement}
-        </h5>
-        <p className="text-center border-b">{importerName}</p>
-        <p className="mb-6 text-center">(Importing Party)</p>
+        <h5 className="mb-4 font-bold">Declaration by the exporter or producer</h5>
+        <h5 className="mb-4 font-bold">{firstSignatoryAuthentication?.statement}</h5>
+        <div className="text-center py-8">
+          <p className="border-b border-dashed">{importerDetails?.importerName}</p>
+          <p className="mb-6 text-center">(Importing Party)</p>
+        </div>
       </>
     );
   };
@@ -101,13 +98,14 @@ export const SimpleCooTemplate: FunctionComponent<TemplateProps<SimpleCooDocumen
   const FirstSignatureSection: FunctionComponent = () => {
     return (
       <>
-        <p className="mb-4">
-          comply with the origin requirements specified in the
-          <br />
-          {documentName}.<br />
-          {loadingBaseportLocationName}, {firstSignatoryAuthentication?.actualDate}
+        {documentName && <p className="mb-4">comply with the origin requirements specified in the {documentName}.</p>}
+        <p>
+          {descriptionOfGoods?.loadingBaseportLocationName && `${descriptionOfGoods?.loadingBaseportLocationName}, `}{" "}
+          {firstSignatoryAuthentication?.actualDate}
         </p>
-        <img className="w-1/2 mx-auto" src={firstSignatoryAuthentication?.signature} />
+        {firstSignatoryAuthentication && (
+          <img data-testid="signature-first" className="w-1/2 mx-auto" src={firstSignatoryAuthentication?.signature} />
+        )}
         <SignatureLine />
       </>
     );
@@ -117,7 +115,13 @@ export const SimpleCooTemplate: FunctionComponent<TemplateProps<SimpleCooDocumen
     return (
       <div className="flex flex-col justify-between h-full">
         <h5 className="mb-4 font-bold">Certification</h5>
-        <img className="w-1/2 mx-auto" src={secondSignatoryAuthentication?.signature} />
+        {secondSignatoryAuthentication && (
+          <img
+            data-testid="signature-second"
+            className="w-1/2 mx-auto"
+            src={secondSignatoryAuthentication?.signature}
+          />
+        )}
         <div>
           <SignatureLine />
         </div>
@@ -152,36 +156,48 @@ export const SimpleCooTemplate: FunctionComponent<TemplateProps<SimpleCooDocumen
             <ImporterSection />
           </div>
           <div className="w-1/3 p-3">
-            <StandardSection label="Time and Date Issued" value={`${issueDateAndTime}`} />
+            <StandardSection label="Time and Date Issued" value={issueDateAndTime} />
           </div>
         </div>
 
         <div className="flex border-b">
           <div className="w-1/3 p-3 border-r">
-            <StandardSection label="Included Consignments" value={includedConsignments} />
+            <StandardSection label="Included Consignments" value={descriptionOfGoods?.includedConsignments} />
           </div>
           <div className="w-1/3 p-3 border-r">
-            <StandardSection label="Importer Name Marks and Number" value={importerNameMarksAndNumber} />
+            <StandardSection
+              label="Importer Name Marks and Number"
+              value={descriptionOfGoods?.importerNameMarksAndNumber}
+            />
           </div>
           <div className="w-1/3 p-3">
-            <StandardSection label="H.S. Code" value={hsCode} />
+            <StandardSection label="H.S. Code" value={descriptionOfGoods?.hsCode} />
           </div>
         </div>
         <div className="p-3 border-b">
-          <StandardSection label="Number and Kind of package; Description of Goods" value={numberAndKindOfPackage} />
+          <StandardSection
+            label="Number and Kind of package; Description of Goods"
+            value={descriptionOfGoods?.numberAndKindOfPackage}
+          />
         </div>
         <div className="flex border-b">
           <div className="w-1/4 p-3 border-r">
-            <StandardSection label="Invoice Number" value={invoiceNumber} />
+            <StandardSection label="Invoice Number" value={descriptionOfGoods?.invoiceNumber} />
           </div>
           <div className="w-1/4 p-3 border-r">
-            <StandardSection label="Date of Invoice" value={dateOfInvoice} />
+            <StandardSection label="Date of Invoice" value={descriptionOfGoods?.dateOfInvoice} />
           </div>
           <div className="w-1/4 p-3 border-r">
-            <StandardSection label="Loading Baseport Location Name" value={loadingBaseportLocationName} />
+            <StandardSection
+              label="Loading Baseport Location Name"
+              value={descriptionOfGoods?.loadingBaseportLocationName}
+            />
           </div>
           <div className="w-1/4 p-3">
-            <StandardSection label="Main Carriage Transport Movement ID" value={mainCarriageTransportMovementId} />
+            <StandardSection
+              label="Main Carriage Transport Movement ID"
+              value={descriptionOfGoods?.mainCarriageTransportMovementId}
+            />
           </div>
         </div>
         <div className="flex">

--- a/src/templates/SimpleCoo/sampleV2.ts
+++ b/src/templates/SimpleCoo/sampleV2.ts
@@ -1,0 +1,64 @@
+import { v2 } from "@govtechsg/open-attestation";
+import { firstSignature, secondSignature } from "./signatures";
+import { SimpleCooDocumentSchemaV2 } from "./types";
+
+export const SimpleCooSampleV2: SimpleCooDocumentSchemaV2 = {
+  $template: {
+    type: v2.TemplateType.EmbeddedRenderer,
+    name: "SIMPLE_COO",
+    url: "http://localhost:3000",
+  },
+  issuers: [
+    {
+      name: "abc",
+      documentStore: "0x1245e5B64D785b25057f7438F715f4aA5D965733",
+      identityProof: {
+        type: v2.IdentityProofType.DNSTxt,
+        location: "demo-tradetrust.openattestation.com",
+      },
+    },
+  ],
+  documentName: "Form for Free Trade Agreement",
+  issueDateAndTime: "21 September 2021, 3:05pm",
+  issueIn: "IMDA Singapore",
+  cooId: "IMDA0001",
+  exporterDetails: {
+    exportCountry: "AU",
+    exporterName: "TREASURY WINE ESTATES VINTNERS LIMITED",
+    exporterAddress: {
+      line1: "161 Collins Street, Melbourne",
+      line2: "VIC Australia",
+      postalCode: "3000 ",
+    },
+  },
+  importerDetails: {
+    importCountry: "SG",
+    importerName: "Singapore Wines Pte Ltd",
+    importerAddress: {
+      line1: "10 Pasir Panjang Road",
+      line2: "#03-01, Mapletree Business City",
+      postalCode: "Singapore 117438",
+    },
+  },
+  descriptionOfGoods: {
+    includedConsignments: "SG",
+    importerNameMarksAndNumber: "SSCC: 59312345670002345",
+    numberAndKindOfPackage: "Bin 23 Pinot Noir 201",
+    hsCode: "2204.21",
+    invoiceNumber: "1122345",
+    dateOfInvoice: "5 July 2021",
+    loadingBaseportLocationName: "AUMEL",
+    mainCarriageTransportMovementId: "IMO 9367815",
+  },
+  firstSignatoryAuthentication: {
+    actualDate: "21 September 2021",
+    statement:
+      "The undersigned hereby declares that the above-stated information is correct and that the goods exported to",
+    signature: firstSignature,
+  },
+  secondSignatoryAuthentication: {
+    actualDate: "",
+    statement: "",
+    signature: secondSignature,
+  },
+};

--- a/src/templates/SimpleCoo/sampleV3.ts
+++ b/src/templates/SimpleCoo/sampleV3.ts
@@ -1,12 +1,12 @@
 import { v3 } from "@govtechsg/open-attestation";
 import { firstSignature, secondSignature } from "./signatures";
-import { SimpleCooDocumentSchema } from "./types";
+import { SimpleCooDocumentSchemaV3 } from "./types";
 
-export const SimpleCooSample: SimpleCooDocumentSchema = {
+export const SimpleCooSampleV3: SimpleCooDocumentSchemaV3 = {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://schemata.openattestation.com/io/tradetrust/certificate-of-origin/1.0/CertificateOfOrigin.v3.json",
     "https://schemata.openattestation.com/com/openattestation/1.0/OpenAttestation.v3.json",
+    // TODO: simple coo has no v3 schema defined at schemata yet -> https://schemata.openattestation.com
   ],
   type: ["VerifiableCredential", "OpenAttestationCredential"],
   issuanceDate: "2010-01-01T19:23:24Z",

--- a/src/templates/SimpleCoo/types.ts
+++ b/src/templates/SimpleCoo/types.ts
@@ -1,9 +1,12 @@
-import { v3 } from "@govtechsg/open-attestation";
+import { v2, v3 } from "@govtechsg/open-attestation";
 
-export type SimpleCooDocumentSchema = v3.OpenAttestationDocument & {
+export type SimpleCooDocumentSchemaV2 = v2.OpenAttestationDocument & SimpleCooDocument;
+
+export type SimpleCooDocumentSchemaV3 = v3.OpenAttestationDocument & {
   credentialSubject: SimpleCooDocument;
 };
 
+export type SimpleCooDocumentSchema = SimpleCooDocumentSchemaV2 | SimpleCooDocumentSchemaV3;
 export interface SimpleCooDocument {
   documentName: string;
   issueIn?: string;


### PR DESCRIPTION
- simple coo template to render v2, v3 data (v3 schemata not exists yet)
- empty example for empty look (should not error out)

<img width="1298" alt="empty" src="https://user-images.githubusercontent.com/4774314/135587424-b4ecd438-6962-4b2a-a648-bce63f7502b7.png">
