### PR TITLE
feat: added error boundary for templates

### DIFF
--- a/src/core/ErrorBoundary/ErrorBoundary.stories.tsx
+++ b/src/core/ErrorBoundary/ErrorBoundary.stories.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import { FunctionComponent } from "react";
+import { ErrorBoundary } from "./ErrorBoundary";
+
+export default {
+  title: "Error/ErrorBoundary",
+  component: ErrorBoundary,
+  parameters: {
+    componentSubtitle: "ErrorBoundary.",
+  },
+};
+
+const ErrorComponent: FunctionComponent = () => {
+  const error = new Error("Error encountered");
+  error.stack =
+    "Lorem ipsum dolor sit, amet consectetur adipisicing elit. At ad rem quae quis, dolorem dicta mollitia accusamus? Reprehenderit et veniam deleniti! Provident et saepe in, excepturi possimus blanditiis consectetur rem.";
+  throw error;
+};
+export const Default: FunctionComponent = () => (
+  <ErrorBoundary>
+    <ErrorComponent />
+  </ErrorBoundary>
+);

--- a/src/core/ErrorBoundary/ErrorBoundary.tsx
+++ b/src/core/ErrorBoundary/ErrorBoundary.tsx
@@ -9,7 +9,7 @@ interface ErrorBoundaryState {
   error: { message: string; stack: string };
 }
 
-class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
   constructor(props: ErrorBoundaryProps) {
     super(props);
     this.state = { hasError: false, error: { message: "", stack: "" } };
@@ -25,7 +25,7 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
       // You can render any custom fallback UI
       return (
         <div>
-          <h1 className="text-xl font-bold mb-2">Document could not be rendered</h1>
+          <h1 className="text-xl font-bold mb-2">Template renderer encountered an error</h1>
           <div className="mb-2">
             <span className="font-medium">Message:</span> {this.state.error.message}
           </div>
@@ -39,5 +39,3 @@ class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundarySta
     return this.props.children;
   }
 }
-
-export default ErrorBoundary;

--- a/src/core/ErrorBoundary/index.ts
+++ b/src/core/ErrorBoundary/index.ts
@@ -1,0 +1,1 @@
+export * from "./ErrorBoundary";

--- a/src/core/Wrapper/Wrapper.tsx
+++ b/src/core/Wrapper/Wrapper.tsx
@@ -1,10 +1,13 @@
 import React, { FunctionComponent } from "react";
+import ErrorBoundary from "../../errorBoundary";
 
 // `container mx-auto px-4` <- this is in line with tt and creator's tw config, so containers can align
 export const Wrapper: FunctionComponent = ({ children, ...props }) => {
   return (
-    <div className="container mx-auto px-4 py-4" {...props}>
-      {children}
-    </div>
+    <ErrorBoundary>
+      <div className="container mx-auto px-4 py-4" {...props}>
+        {children}
+      </div>
+    </ErrorBoundary>
   );
 };

--- a/src/core/Wrapper/Wrapper.tsx
+++ b/src/core/Wrapper/Wrapper.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from "react";
-import ErrorBoundary from "../../errorBoundary";
+import { ErrorBoundary } from "../ErrorBoundary";
 
 // `container mx-auto px-4` <- this is in line with tt and creator's tw config, so containers can align
 export const Wrapper: FunctionComponent = ({ children, ...props }) => {

--- a/src/errorBoundary.tsx
+++ b/src/errorBoundary.tsx
@@ -1,0 +1,43 @@
+import React, { ReactNode } from "react";
+
+interface ErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface ErrorBoundaryState {
+  hasError: boolean;
+  error: { message: string; stack: string };
+}
+
+class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoundaryState> {
+  constructor(props: ErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false, error: { message: "", stack: "" } };
+  }
+
+  static getDerivedStateFromError(error: ErrorBoundaryState["error"]): ErrorBoundaryState {
+    // Update state so the next render will show the fallback UI.
+    return { hasError: true, error };
+  }
+
+  render(): ReactNode {
+    if (this.state.hasError) {
+      // You can render any custom fallback UI
+      return (
+        <div>
+          <h1 className="text-xl font-bold mb-2">Document could not be rendered</h1>
+          <div className="mb-2">
+            <span className="font-medium">Message:</span> {this.state.error.message}
+          </div>
+          <div className="mb-2">
+            <span className="font-medium">Stack:</span> {this.state.error.stack}
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;


### PR DESCRIPTION
## Summary

What is the background of this pull request?

Error in renderer results in blank document

## Changes

- Added error boundary to display error message and stack trace 

## Issues

[179715410](https://www.pivotaltracker.com/story/show/179715410)
