### PR TITLE
feat: asset modules

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  coverageDirectory: "coverage",
+  moduleNameMapper: {
+    "\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$":
+      "<rootDir>/__mocks__/fileMock.js",
+    "\\.(css|less)$": "<rootDir>/__mocks__/fileMock.js",
+    "\\.*?inline$": "<rootDir>/__mocks__/fileMock.js",
+  },
+  setupFilesAfterEnv: ["./jest.setup.ts"],
+  testEnvironment: "jest-environment-jsdom",
+  testRegex: "(/__tests__/.*|(\\.|/)(test))\\.tsx?$",
+};

--- a/package.json
+++ b/package.json
@@ -141,18 +141,6 @@
       }
     ]
   },
-  "jest": {
-    "coverageDirectory": "coverage",
-    "moduleNameMapper": {
-      "\\.(jpg|ico|jpeg|png|gif|eot|otf|webp|svg|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$": "<rootDir>/__mocks__/fileMock.js",
-      "\\.(css|less)$": "<rootDir>/__mocks__/fileMock.js"
-    },
-    "setupFilesAfterEnv": [
-      "./jest.setup.ts"
-    ],
-    "testEnvironment": "jest-environment-jsdom",
-    "testRegex": "(/__tests__/.*|(\\.|/)(test))\\.tsx?$"
-  },
   "dependencies": {
     "@emotion/react": "^11.8.1",
     "@emotion/styled": "^11.8.1",

--- a/package.json
+++ b/package.json
@@ -203,7 +203,6 @@
     "eslint-plugin-react": "^7.28.0",
     "eslint-plugin-react-hooks": "^4.3.0",
     "eslint-plugin-testcafe-community": "^2.0.0",
-    "file-loader": "^6.2.0",
     "html-webpack-plugin": "^5.5.0",
     "jest": "^27.5.1",
     "npm-run-all": "^4.1.5",

--- a/src/@types/declaration.d.ts
+++ b/src/@types/declaration.d.ts
@@ -2,6 +2,12 @@ declare module "*.png" {
   const value: any;
   export default value;
 }
+
+declare module "*?inline" {
+  const value: any;
+  export default value;
+} // https://webpack.js.org/guides/asset-modules/#replacing-inline-loader-syntax
+
 declare module "*.jpg" {
   const value: any;
   export default value;

--- a/src/templates/CoveringLetter/sample2.ts
+++ b/src/templates/CoveringLetter/sample2.ts
@@ -1,6 +1,6 @@
 import { v2 } from "@govtechsg/open-attestation";
 import { CoveringLetter } from "./types";
-import logo from "/static/images/logo-dbs.png";
+import logo from "/static/images/logo-dbs.png?inline";
 
 export const CoveringLetterSample2: CoveringLetter = {
   $template: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,11 +31,11 @@ module.exports = {
       },
       {
         test: /\.(png|jpe?g|gif|svg)$/i,
-        use: [
-          {
-            loader: "file-loader",
-          },
-        ],
+        type: "asset",
+      },
+      {
+        resourceQuery: /inline/,
+        type: "asset/inline",
       },
       {
         test: /\.css$/i,
@@ -68,18 +68,13 @@ module.exports = {
       },
     },
   },
-
-  // Using eval-cheap-module-source-map for build times
-  // switch to inline-source-map if detailed debugging needed
-  devtool: IS_PROD ? false : "eval-cheap-module-source-map",
-
+  devtool: IS_PROD ? false : "eval-cheap-module-source-map", // https://webpack.js.org/configuration/devtool
   devServer: {
     compress: true,
     historyApiFallback: true,
     hot: true,
     port: 3000,
   },
-
   resolve: {
     extensions: [".js", ".ts", ".tsx"],
     modules: ["node_modules", path.resolve(__dirname, "src")],


### PR DESCRIPTION
- file-loader, url-loader, raw-loader deprecated with webpack 5
- use asset modules as recommended
- fix broken dbs logo image
- https://webpack.js.org/guides/asset-modules
- https://www.typescriptlang.org/docs/handbook/modules.html#wildcard-module-declarations