### PR TITLE
test: wrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ _Note: These are just some rendering templates that are made available for users
 | Bill of Lading                  | EMBEDDED_RENDERER | BILL_OF_LADING                  | &cross;    | &check;      | &check;       | -              |
 | Bill of Lading (Generic)        | EMBEDDED_RENDERER | BILL_OF_LADING_GENERIC          | &cross;    | &check;      | -             | -              |
 | Bill of Lading (Carrier)        | EMBEDDED_RENDERER | BILL_OF_LADING_CARRIER          | &cross;    | &check;      | -             | -              |
-| Chafta COO                      | EMBEDDED_RENDERER | CHAFTA_COO                      | &check;    | &cross;      | &check;       | -              |
+| Chafta COO                      | EMBEDDED_RENDERER | CHAFTA_COO                      | &check;    | &cross;      | -             | -              |
 | Covering Letter                 | EMBEDDED_RENDERER | COVERING_LETTER                 | &check;    | &cross;      | &check;       | -              |
 | Invoice                         | EMBEDDED_RENDERER | INVOICE                         | &check;    | &cross;      | &check;       | &check;        |
-| Simple COO                      | EMBEDDED_RENDERER | SIMPLE_COO                      | &check;    | &cross;      | &check;       | -              |
+| Simple COO                      | EMBEDDED_RENDERER | SIMPLE_COO                      | &check;    | &cross;      | -             | -              |
 | Certificate of Non Manipulation | EMBEDDED_RENDERER | CERTIFICATE_OF_NON_MANIPULATION | &check;    | &cross;      | -             | -              |
 
 In the `forms[0].defaults.$template` field of the configuration file, refer to the above for the `type`, `name`, and `url` values.

--- a/src/templates/BillOfLading/BillOfLadingTemplate.test.tsx
+++ b/src/templates/BillOfLading/BillOfLadingTemplate.test.tsx
@@ -1,5 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
+import {
+  utils,
+  wrapDocument,
+  __unsafe__use__it__at__your__own__risks__wrapDocument as wrapDocumentV3,
+} from "@govtechsg/open-attestation";
 import { BillOfLadingTemplate } from "./BillOfLadingTemplate";
 import { BillOfLadingSampleV2 } from "./sampleV2";
 import { BillOfLadingSampleV3 } from "./sampleV3";
@@ -14,6 +19,11 @@ describe("bill of lading V2", () => {
     render(<BillOfLadingTemplate document={BillOfLadingSampleV2} handleObfuscation={() => {}} />);
     expect(screen.getByTestId("logo")).toHaveAttribute("src", "test-file-stub");
   });
+
+  it("should be able to wrap v2", () => {
+    const wrappedDocument = wrapDocument(BillOfLadingSampleV2);
+    expect(utils.isWrappedV2Document(wrappedDocument)).toBe(true);
+  });
 });
 
 describe("bill of lading V3", () => {
@@ -25,5 +35,10 @@ describe("bill of lading V3", () => {
   it("should render tradetrust logo", () => {
     render(<BillOfLadingTemplate document={BillOfLadingSampleV3} handleObfuscation={() => {}} />);
     expect(screen.getByTestId("logo")).toHaveAttribute("src", "test-file-stub");
+  });
+
+  it("should be able to wrap v3", async () => {
+    const wrappedDocument = await wrapDocumentV3(BillOfLadingSampleV3);
+    expect(utils.isWrappedV3Document(wrappedDocument)).toBe(true);
   });
 });

--- a/src/templates/BillOfLading/sampleV2.ts
+++ b/src/templates/BillOfLading/sampleV2.ts
@@ -11,6 +11,10 @@ export const BillOfLadingSampleV2: BillOfLadingSchemaV2 = {
     {
       name: "abc",
       tokenRegistry: "0x142Ca30e3b78A840a82192529cA047ED759a6F7e",
+      identityProof: {
+        type: v2.IdentityProofType.DNSTxt,
+        location: "example.tradetrust.io",
+      },
     },
   ],
   links: {

--- a/src/templates/BillOfLadingCarrierTemplate/BillOfLadingCarrierTemplate.test.tsx
+++ b/src/templates/BillOfLadingCarrierTemplate/BillOfLadingCarrierTemplate.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
+import { utils, wrapDocument } from "@govtechsg/open-attestation";
 import { BillOfLadingCarrierTemplate } from "./BillOfLadingCarrierTemplate";
 import { BillOfLadingCarrierSampleV2 } from "./sampleV2";
 
@@ -43,5 +44,10 @@ describe("bill of lading V2 (Carrier)", () => {
     expect(screen.queryByTestId("place-of-issue-bl")).not.toBeInTheDocument();
     expect(screen.getByTestId("number-of-original-bl")).toHaveTextContent("ONE/1");
     expect(screen.queryByTestId("date-of-issue-bl")).not.toBeInTheDocument();
+  });
+
+  it("should be able to wrap v2", () => {
+    const wrappedDocument = wrapDocument(BillOfLadingCarrierSampleV2);
+    expect(utils.isWrappedV2Document(wrappedDocument)).toBe(true);
   });
 });

--- a/src/templates/BillOfLadingCarrierTemplate/sampleV2.ts
+++ b/src/templates/BillOfLadingCarrierTemplate/sampleV2.ts
@@ -13,6 +13,10 @@ export const BillOfLadingCarrierSampleV2: BillOfLadingCarrierSchemaV2 = {
     {
       name: "abc",
       tokenRegistry: "0x142Ca30e3b78A840a82192529cA047ED759a6F7e",
+      identityProof: {
+        type: v2.IdentityProofType.DNSTxt,
+        location: "example.tradetrust.io",
+      },
     },
   ],
   scac: "SGPU",

--- a/src/templates/BillOfLadingGeneric/BillOfLadingGenericTemplate.test.tsx
+++ b/src/templates/BillOfLadingGeneric/BillOfLadingGenericTemplate.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
+import { utils, wrapDocument } from "@govtechsg/open-attestation";
 import { BillOfLadingGenericTemplate } from "./BillOfLadingGenericTemplate";
 import { BillOfLadingGenericSample } from "./sample";
 
@@ -17,5 +18,10 @@ describe("bill of lading", () => {
   it("should render fields 1-9 content correctly", () => {
     render(<BillOfLadingGenericTemplate document={BillOfLadingGenericSample} handleObfuscation={() => {}} />);
     expect(screen.getAllByText("Hello")).toHaveLength(9);
+  });
+
+  it("should be able to wrap v2", () => {
+    const wrappedDocument = wrapDocument(BillOfLadingGenericSample);
+    expect(utils.isWrappedV2Document(wrappedDocument)).toBe(true);
   });
 });

--- a/src/templates/BillOfLadingGeneric/sample.ts
+++ b/src/templates/BillOfLadingGeneric/sample.ts
@@ -12,6 +12,10 @@ export const BillOfLadingGenericSample: BillOfLadingGeneric = {
     {
       name: "abc",
       tokenRegistry: "0x142Ca30e3b78A840a82192529cA047ED759a6F7e",
+      identityProof: {
+        type: v2.IdentityProofType.DNSTxt,
+        location: "example.tradetrust.io",
+      },
     },
   ],
   blNumber: "SGCNM21566325",

--- a/src/templates/BillOfLadingMaerskPilot/BillOfLadingMaerskPilotTemplate.test.tsx
+++ b/src/templates/BillOfLadingMaerskPilot/BillOfLadingMaerskPilotTemplate.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
+import { utils, wrapDocument } from "@govtechsg/open-attestation";
 import { BillOfLadingMaerskPilotTemplate } from "./BillOfLadingMaerskPilotTemplate";
 import { BillOfLadingMaerskPilotSampleV2 } from "./sampleV2";
 
@@ -44,5 +45,10 @@ describe("bill of lading V2 (Maersk Pilot)", () => {
     expect(screen.queryByTestId("place-of-issue-bl")).not.toBeInTheDocument();
     expect(screen.getByTestId("number-of-original-bl")).toHaveTextContent("ONE/1");
     expect(screen.queryByTestId("date-of-issue-bl")).not.toBeInTheDocument();
+  });
+
+  it("should be able to wrap v2", () => {
+    const wrappedDocument = wrapDocument(BillOfLadingMaerskPilotSampleV2);
+    expect(utils.isWrappedV2Document(wrappedDocument)).toBe(true);
   });
 });

--- a/src/templates/BillOfLadingMaerskPilot/sampleV2.ts
+++ b/src/templates/BillOfLadingMaerskPilot/sampleV2.ts
@@ -13,6 +13,10 @@ export const BillOfLadingMaerskPilotSampleV2: BillOfLadingMaerskPilotSchemaV2 = 
     {
       name: "abc",
       tokenRegistry: "0x142Ca30e3b78A840a82192529cA047ED759a6F7e",
+      identityProof: {
+        type: v2.IdentityProofType.DNSTxt,
+        location: "example.tradetrust.io",
+      },
     },
   ],
   scac: "SGPU",

--- a/src/templates/BillOfLadingMaerskTpac/BillOfLadingMaerskTpacTemplate.test.tsx
+++ b/src/templates/BillOfLadingMaerskTpac/BillOfLadingMaerskTpacTemplate.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
+import { utils, wrapDocument } from "@govtechsg/open-attestation";
 import { BillOfLadingMaerskTpacTemplate } from "./BillOfLadingMaerskTpacTemplate";
 import { BillOfLadingMaerskTpacSampleV2 } from "./sampleV2";
 
@@ -44,5 +45,10 @@ describe("bill of lading V2 (Maersk Pilot)", () => {
     expect(screen.queryByTestId("place-of-issue-bl")).toHaveTextContent("");
     expect(screen.getByTestId("number-of-original-bl")).toHaveTextContent("ONE/1");
     expect(screen.queryByTestId("date-of-issue-bl")).toHaveTextContent("");
+  });
+
+  it("should be able to wrap v2", () => {
+    const wrappedDocument = wrapDocument(BillOfLadingMaerskTpacSampleV2);
+    expect(utils.isWrappedV2Document(wrappedDocument)).toBe(true);
   });
 });

--- a/src/templates/BillOfLadingMaerskTpac/sampleV2.ts
+++ b/src/templates/BillOfLadingMaerskTpac/sampleV2.ts
@@ -13,6 +13,10 @@ export const BillOfLadingMaerskTpacSampleV2: BillOfLadingMaerskTpacSchemaV2 = {
     {
       name: "abc",
       tokenRegistry: "0x142Ca30e3b78A840a82192529cA047ED759a6F7e",
+      identityProof: {
+        type: v2.IdentityProofType.DNSTxt,
+        location: "example.tradetrust.io",
+      },
     },
   ],
   scac: "SGPU",

--- a/src/templates/Brochure/sampleV2.ts
+++ b/src/templates/Brochure/sampleV2.ts
@@ -11,6 +11,10 @@ export const BrochureSampleV2: BrochureSchema = {
     {
       name: "abc",
       documentStore: "0x1245e5B64D785b25057f7438F715f4aA5D965733",
+      identityProof: {
+        type: v2.IdentityProofType.DNSTxt,
+        location: "example.tradetrust.io",
+      },
     },
   ],
   shared: {
@@ -184,7 +188,7 @@ export const BrochureSampleV2: BrochureSchema = {
               `While the claims contained within verifiable credentials are machine-readable, they are not by default
             presented in a human-readable form. OpenAttestation implements a decentralised rendering protocol that presents
             the OpenAttestation verifiable credential in a human-readable format. Issuers create their own document schema and
-            custom templates to render their OpenAttestation verifiable credentials. This decentralised renderer is publicly 
+            custom templates to render their OpenAttestation verifiable credentials. This decentralised renderer is publicly
             hosted as an endpoint.`,
               `When verifiers verify the OpenAttestation verifiable credential online, the OpenAttestation viewer then loads
             the decentralised renderer and uses it to display the OpenAttestation verifiable credential. This protocol enables

--- a/src/templates/CertificateOfNonManipulation/CertificateOfNonManipulationTemplate.test.tsx
+++ b/src/templates/CertificateOfNonManipulation/CertificateOfNonManipulationTemplate.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
+import { utils, wrapDocument } from "@govtechsg/open-attestation";
 import { CertificateOfNonManipulationTemplate } from "./CertificateOfNonManipulationTemplate";
 import { CertificateOfNonManipulationSampleV2 } from "./sampleV2";
 
@@ -35,5 +36,10 @@ describe("certificate of non manipulation", () => {
       "src",
       CertificateOfNonManipulationSampleV2.certification?.stamp
     );
+  });
+
+  it("should be able to wrap v2", () => {
+    const wrappedDocument = wrapDocument(CertificateOfNonManipulationSampleV2);
+    expect(utils.isWrappedV2Document(wrappedDocument)).toBe(true);
   });
 });

--- a/src/templates/CertificateOfNonManipulation/sampleV2.ts
+++ b/src/templates/CertificateOfNonManipulation/sampleV2.ts
@@ -11,6 +11,10 @@ export const CertificateOfNonManipulationSampleV2: CertificateOfNonManipulationS
     {
       name: "abc",
       documentStore: "0x1245e5B64D785b25057f7438F715f4aA5D965733",
+      identityProof: {
+        type: v2.IdentityProofType.DNSTxt,
+        location: "example.tradetrust.io",
+      },
     },
   ],
   id: "SGCNM21566325",

--- a/src/templates/ChaftaCoo/ChaftaCooTemplate.test.tsx
+++ b/src/templates/ChaftaCoo/ChaftaCooTemplate.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
+import { utils, wrapDocument } from "@govtechsg/open-attestation";
 import { ChaftaCooTemplate } from "./ChaftaCooTemplate";
 import { ChaftaCooSampleV2 } from "./sampleV2";
 import { ChaftaCooSampleV3 } from "./sampleV3";
@@ -14,6 +15,11 @@ describe("chafta coo v2", () => {
     render(<ChaftaCooTemplate document={ChaftaCooSampleV2} handleObfuscation={() => {}} />);
     expect(screen.getByTestId("signature")).toBeInTheDocument();
   });
+
+  it("should be able to wrap v2", () => {
+    const wrappedDocument = wrapDocument(ChaftaCooSampleV2);
+    expect(utils.isWrappedV2Document(wrappedDocument)).toBe(true);
+  });
 });
 
 describe("chafta coo v3", () => {
@@ -26,4 +32,10 @@ describe("chafta coo v3", () => {
     render(<ChaftaCooTemplate document={ChaftaCooSampleV3} handleObfuscation={() => {}} />);
     expect(screen.getByTestId("signature")).toBeInTheDocument();
   });
+
+  // eslint-disable-next-line jest/no-commented-out-tests
+  // it("should be able to wrap v3", async () => {
+  //   const wrappedDocument = await wrapDocumentV3(ChaftaCooSampleV3);
+  //   expect(utils.isWrappedV3Document(wrappedDocument)).toBe(true);
+  // }); // TODO: v3 schema fields did not tally at schemata yet
 });

--- a/src/templates/ChaftaCoo/sampleV3.ts
+++ b/src/templates/ChaftaCoo/sampleV3.ts
@@ -4,7 +4,7 @@ import { ChaftaCooDocumentSchemaV3 } from "./types";
 export const ChaftaCooSampleV3: ChaftaCooDocumentSchemaV3 = {
   "@context": [
     "https://www.w3.org/2018/credentials/v1",
-    "https://schemata.openattestation.com/io/tradetrust/certificate-of-origin/1.0/CertificateOfOrigin.v3.json",
+    "https://schemata.openattestation.com/io/tradetrust/certificate-of-origin/1.0/certificate-of-origin-context.json", // TODO: v3 schema fields did not tally at schemata yet
     "https://schemata.openattestation.com/com/openattestation/1.0/OpenAttestation.v3.json",
   ],
   type: ["VerifiableCredential", "OpenAttestationCredential"],

--- a/src/templates/CoveringLetter/CoveringLetterTemplate.test.tsx
+++ b/src/templates/CoveringLetter/CoveringLetterTemplate.test.tsx
@@ -1,11 +1,16 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
+import {
+  utils,
+  wrapDocument,
+  __unsafe__use__it__at__your__own__risks__wrapDocument as wrapDocumentV3,
+} from "@govtechsg/open-attestation";
 import { CoveringLetterTemplate } from "./CoveringLetterTemplate";
 import { CoveringLetterSampleV2a } from "./sampleV2a";
 import { CoveringLetterSampleV2b } from "./sampleV2b";
 import { CoveringLetterSampleV3 } from "./sampleV3";
 
-describe("covering Letter", () => {
+describe("covering Letter v2", () => {
   it("should render the cover letter v2 (govtech) correctly", () => {
     render(<CoveringLetterTemplate document={CoveringLetterSampleV2a} handleObfuscation={() => {}} />);
     expect(screen.getByText("Documents Bundle")).toBeInTheDocument();
@@ -21,6 +26,18 @@ describe("covering Letter", () => {
     expect(screen.getByTestId("logo")).toHaveAttribute("src", "test-file-stub");
   });
 
+  it("should be able to wrap v2, sample a", () => {
+    const wrappedDocument = wrapDocument(CoveringLetterSampleV2a);
+    expect(utils.isWrappedV2Document(wrappedDocument)).toBe(true);
+  });
+
+  it("should be able to wrap v2, sample b", () => {
+    const wrappedDocument = wrapDocument(CoveringLetterSampleV2b);
+    expect(utils.isWrappedV2Document(wrappedDocument)).toBe(true);
+  });
+});
+
+describe("covering Letter v3", () => {
   it("should render the cover letter v3 with customised values correctly", () => {
     const {
       credentialSubject: { titleColor, remarksColor },
@@ -34,5 +51,10 @@ describe("covering Letter", () => {
     const computedRemarksColor = getComputedStyle(screen.getByText("Remarks:")).color;
     expect(computedTitleColor).toBe(titleColor);
     expect(computedRemarksColor).toBe(remarksColor);
+  });
+
+  it("should be able to wrap v3", async () => {
+    const wrappedDocument = await wrapDocumentV3(CoveringLetterSampleV3);
+    expect(utils.isWrappedV3Document(wrappedDocument)).toBe(true);
   });
 });

--- a/src/templates/CoveringLetter/sampleV2a.ts
+++ b/src/templates/CoveringLetter/sampleV2a.ts
@@ -11,6 +11,10 @@ export const CoveringLetterSampleV2a: CoveringLetterSchemaV2 = {
     {
       name: "abc",
       documentStore: "0x1245e5B64D785b25057f7438F715f4aA5D965733",
+      identityProof: {
+        type: v2.IdentityProofType.DNSTxt,
+        location: "example.tradetrust.io",
+      },
     },
   ],
   links: {

--- a/src/templates/CoveringLetter/sampleV2b.ts
+++ b/src/templates/CoveringLetter/sampleV2b.ts
@@ -12,6 +12,10 @@ export const CoveringLetterSampleV2b: CoveringLetterSchemaV2 = {
     {
       name: "abc",
       documentStore: "0x1245e5B64D785b25057f7438F715f4aA5D965733",
+      identityProof: {
+        type: v2.IdentityProofType.DNSTxt,
+        location: "example.tradetrust.io",
+      },
     },
   ],
   links: {

--- a/src/templates/CoveringLetter/sampleV2malformed.ts
+++ b/src/templates/CoveringLetter/sampleV2malformed.ts
@@ -11,6 +11,10 @@ export const CoveringLetterSampleV2malformed: CoveringLetterSchemaV2 = {
     {
       name: "abc",
       documentStore: "0x1245e5B64D785b25057f7438F715f4aA5D965733",
+      identityProof: {
+        type: v2.IdentityProofType.DNSTxt,
+        location: "example.tradetrust.io",
+      },
     },
   ],
   links: {

--- a/src/templates/Invoice/InvoiceTemplate.test.tsx
+++ b/src/templates/Invoice/InvoiceTemplate.test.tsx
@@ -1,10 +1,15 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
+import {
+  utils,
+  wrapDocument,
+  __unsafe__use__it__at__your__own__risks__wrapDocument as wrapDocumentV3,
+} from "@govtechsg/open-attestation";
 import { InvoiceTemplate } from "./InvoiceTemplate";
 import { InvoiceSampleV2 } from "./sampleV2";
 import { InvoiceSampleV3 } from "./sampleV3";
 
-describe("invoice", () => {
+describe("invoice v2", () => {
   it("should render the V2 invoice correctly", () => {
     render(<InvoiceTemplate document={InvoiceSampleV2} handleObfuscation={() => {}} />);
 
@@ -21,6 +26,13 @@ describe("invoice", () => {
     expect(screen.getByText("BALANCE DUE")).toBeInTheDocument();
   });
 
+  it("should be able to wrap v2", () => {
+    const wrappedDocument = wrapDocument(InvoiceSampleV2);
+    expect(utils.isWrappedV2Document(wrappedDocument)).toBe(true);
+  });
+});
+
+describe("invoice v3", () => {
   it("should render the V3 invoice correctly", () => {
     render(<InvoiceTemplate document={InvoiceSampleV3} handleObfuscation={() => {}} />);
 
@@ -35,5 +47,10 @@ describe("invoice", () => {
     expect(screen.getByText("UNIT PRICE")).toBeInTheDocument();
     expect(screen.getByText("SUBTOTAL")).toBeInTheDocument();
     expect(screen.getByText("BALANCE DUE")).toBeInTheDocument();
+  });
+
+  it("should be able to wrap v3", async () => {
+    const wrappedDocument = await wrapDocumentV3(InvoiceSampleV3);
+    expect(utils.isWrappedV3Document(wrappedDocument)).toBe(true);
   });
 });

--- a/src/templates/Invoice/sampleV2.ts
+++ b/src/templates/Invoice/sampleV2.ts
@@ -11,6 +11,10 @@ export const InvoiceSampleV2: InvoiceDocumentSchemaV2 = {
     {
       name: "abc",
       documentStore: "0x1245e5B64D785b25057f7438F715f4aA5D965733",
+      identityProof: {
+        type: v2.IdentityProofType.DNSTxt,
+        location: "example.tradetrust.io",
+      },
     },
   ],
   links: {

--- a/src/templates/SimpleCoo/SimpleCooTemplate.test.tsx
+++ b/src/templates/SimpleCoo/SimpleCooTemplate.test.tsx
@@ -1,10 +1,6 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
-import {
-  utils,
-  wrapDocument,
-  __unsafe__use__it__at__your__own__risks__wrapDocument as wrapDocumentV3,
-} from "@govtechsg/open-attestation";
+import { utils, wrapDocument } from "@govtechsg/open-attestation";
 import { SimpleCooTemplate } from "./SimpleCooTemplate";
 import { SimpleCooSampleV2 } from "./sampleV2";
 import { SimpleCooSampleV3 } from "./sampleV3";

--- a/src/templates/SimpleCoo/SimpleCooTemplate.test.tsx
+++ b/src/templates/SimpleCoo/SimpleCooTemplate.test.tsx
@@ -1,5 +1,10 @@
 import { render, screen } from "@testing-library/react";
 import React from "react";
+import {
+  utils,
+  wrapDocument,
+  __unsafe__use__it__at__your__own__risks__wrapDocument as wrapDocumentV3,
+} from "@govtechsg/open-attestation";
 import { SimpleCooTemplate } from "./SimpleCooTemplate";
 import { SimpleCooSampleV2 } from "./sampleV2";
 import { SimpleCooSampleV3 } from "./sampleV3";
@@ -19,6 +24,11 @@ describe("simple coo v2", () => {
     render(<SimpleCooTemplate document={SimpleCooSampleV2} handleObfuscation={() => {}} />);
     expect(screen.getByTestId("signature-second")).toBeInTheDocument();
   });
+
+  it("should be able to wrap v2", () => {
+    const wrappedDocument = wrapDocument(SimpleCooSampleV2);
+    expect(utils.isWrappedV2Document(wrappedDocument)).toBe(true);
+  });
 });
 
 describe("simple coo v3", () => {
@@ -36,6 +46,12 @@ describe("simple coo v3", () => {
     render(<SimpleCooTemplate document={SimpleCooSampleV3} handleObfuscation={() => {}} />);
     expect(screen.getByTestId("signature-second")).toBeInTheDocument();
   });
+
+  // eslint-disable-next-line jest/no-commented-out-tests
+  // it("should be able to wrap v3", async () => {
+  //   const wrappedDocument = await wrapDocumentV3(SimpleCooSampleV3);
+  //   expect(utils.isWrappedV3Document(wrappedDocument)).toBe(true);
+  // }); // TODO: simple coo has no v3 schema defined at schemata yet -> https://schemata.openattestation.com
 });
 
 describe("simple coo empty", () => {

--- a/src/templates/XmlRenderer/sample.ts
+++ b/src/templates/XmlRenderer/sample.ts
@@ -11,6 +11,10 @@ export const XMLRendererSampleData: XmlRendererFileInterface = {
     {
       name: "abc",
       documentStore: "0x1245e5B64D785b25057f7438F715f4aA5D965733",
+      identityProof: {
+        type: v2.IdentityProofType.DNSTxt,
+        location: "example.tradetrust.io",
+      },
     },
   ],
   xmlData:

--- a/src/templates/XmlRenderer/xmlRenderer.test.tsx
+++ b/src/templates/XmlRenderer/xmlRenderer.test.tsx
@@ -1,7 +1,8 @@
-import { XMLRenderer } from "./template";
-import { XMLRendererSampleData } from "./sample";
 import { render } from "@testing-library/react";
 import React from "react";
+import { utils, wrapDocument } from "@govtechsg/open-attestation";
+import { XMLRenderer } from "./template";
+import { XMLRendererSampleData } from "./sample";
 
 const emptySample = {
   XMLRendererSampleData,
@@ -50,5 +51,10 @@ describe("xml renderer", () => {
     ).not.toBeInTheDocument();
     expect(queryByText("000166000001")).not.toBeInTheDocument();
     expect(queryByText("8360.00")).not.toBeInTheDocument();
+  });
+
+  it("should be able to wrap v2", () => {
+    const wrappedDocument = wrapDocument(XMLRendererSampleData);
+    expect(utils.isWrappedV2Document(wrappedDocument)).toBe(true);
   });
 });


### PR DESCRIPTION
Obfuscation requires document to be OA compliant. To implement that at example application, we need to ensure our "raw fixtures" are wrappable.

- tests to ensure "raw fixtures" passes OA guards.
- discovered `Chafta COO` and `Simple COO` v3 schema is not up to date meanwhile.
